### PR TITLE
a8_os module added

### DIFF
--- a/examples/a8/a8_os_test.mfk
+++ b/examples/a8/a8_os_test.mfk
@@ -1,0 +1,51 @@
+// Quick test for a8_os.mfk module
+// By Freddy Offenga, 2019
+
+import stdio
+
+void print_hex(word w) {
+	putchar(hi_nibble_to_hex(w.hi))
+	putchar(lo_nibble_to_hex(w.hi))
+	putchar(hi_nibble_to_hex(w.lo))
+	putchar(lo_nibble_to_hex(w.lo))
+}
+
+void main() {
+	// test const byte
+	putchar(os_ATBEL)
+	
+	// test const word
+	print_hex(os_B00600)
+	
+	// test const '<char>'
+	// test volatile byte zp
+	os_LMARGN = os_LMARGN - 2
+	putchar(os_ATEOL)
+	putchar(os_DISK)
+
+	// test volatile byte adr
+	os_COLOR4 = os_COLOR1
+
+	// test volatile word zp
+	const array text = "Hello world!" atasciiscr
+	pointer scr 
+	byte i
+	scr = os_SAVMSC + 120
+	for i,0,to,text.lastindex {
+		scr[i] = text[i]
+	}
+	
+	// test volatile word adr
+	os_CDTMV4 = 1000
+	while (os_CDTMV4 != 0) {
+		print_hex(os_CDTMV4)
+		
+		for i,0,to,3 {
+			putchar(os_ATLRW)
+		}
+	}
+
+	os_COLOR2 = 0
+	
+	while (true) {}
+}

--- a/include/a8.ini
+++ b/include/a8.ini
@@ -1,6 +1,6 @@
 [compilation]
 arch=strict
-modules=a8_hardware,a8_kernel,default_panic,stdlib
+modules=a8_hardware,a8_os,a8_kernel,default_panic,stdlib
 encoding=atascii
 screen_encoding=atasciiscr
 

--- a/include/a8_os.mfk
+++ b/include/a8_os.mfk
@@ -1,0 +1,727 @@
+// Atari System Equates
+//
+// Based on cc65\asminc\atari.inc
+// by Freddy Offenga, Christian Groessler
+//
+// References:
+// - Atari 400/800 OS rev.B source code, Atari 1979
+// - Atari OS manual - XL addendum
+// - Atari XL/XE rev.2 source code, Atari 1984
+// - Mapping the Atari - revised edition, Ian Chadwick 1985
+//
+// ##old##       old OS rev.B label - moved or deleted
+// ##1200xl##    new label introduced in 1200XL OS (rev.10/11)
+// ##rev2##      new label introduced in XL/XE OS rev.2
+
+#if not(ATARI_8)
+#warn a8_os module should be used only on Atari computer-compatible targets
+#endif
+
+const byte os_MAXDEV  = 33            // offset to last possible entry of HATABS
+const byte os_IOCBSZ  = 16            // length of IOCB
+
+const byte os_SEIOCB  = 0*IOCBSZ      // ##rev2## screen editor IOCB index
+const byte os_MAXIOC  = 8*IOCBSZ      // first invalid IOCB index
+
+const byte os_DSCTSZ  = 128           // ##rev2## disk sector size
+
+const byte os_LEDGE   = 2             // left edge
+const byte os_REDGE   = 39            // right edge
+
+// Index values for IOCB
+const byte os_ICHID = $00         // HANDLER INDEX NUMBER (FF=IOCB FREE)
+const byte os_ICDNO = $01         // DEVICE NUMBER (DRIVE NUMBER)
+const byte os_ICCOM = $02         // COMMAND CODE
+const byte os_ICSTA = $03         // STATUS OF LAST IOCB ACTION
+const byte os_ICBAL = $04         // 1-byte low buffer address
+const byte os_ICBAH = $05         // 1-byte high buffer address
+const byte os_ICPTL = $06         // 1-byte low PUT-BYTE routine address - 1
+const byte os_ICPTH = $07         // 1-byte high PUT-BYTE routine address - 1
+const byte os_ICBLL = $08         // 1-byte low buffer length
+const byte os_ICBLH = $09         // 1-byte high buffer length
+const byte os_ICAX1 = $0A         // 1-byte first auxiliary information
+const byte os_ICAX2 = $0B         // 1-byte second auxiliary information
+const byte os_ICAX3 = $0C         // 1-byte third auxiliary information
+const byte os_ICAX4 = $0D         // 1-byte fourth auxiliary information
+const byte os_ICAX5 = $0E         // 1-byte fifth auxiliary information
+const byte os_ICSPR = $0F         // SPARE BYTE
+
+// IOCB Command Code Equates
+
+const byte os_OPEN    = $03           // open
+const byte os_GETREC  = $05           // get record
+const byte os_GETCHR  = $07           // get character(s)
+const byte os_PUTREC  = $09           // put record
+const byte os_PUTCHR  = $0B           // put character(s)
+const byte os_CLOSE   = $0C           // close
+const byte os_STATIS  = $0D           // status
+const byte os_SPECIL  = $0E           // special
+
+// Screen IOCB Commands
+
+const byte os_DRAWLN  = $11           // draw line
+const byte os_FILLIN  = $12           // draw line with right fill
+
+// ICAX1 Auxiliary Byte 1 Equates
+
+const byte os_APPEND  = $01           // open write append (D:)
+const byte os_DIRECT  = $02           // open for directory access (D:)
+const byte os_OPNIN   = $04           // open for input (all devices)
+const byte os_OPNOT   = $08           // open for output (all devices)
+const byte os_MXDMOD  = $10           // open for mixed mode (E:, S:)
+const byte os_INSCLR  = $20           // open for input without clearing screen
+
+// Device Code Equates
+
+const byte os_CASSET  = 'C'           // cassette
+const byte os_DISK    = 'D'           // disk
+const byte os_SCREDT  = 'E'           // screen editor
+const byte os_KBD     = 'K'           // keyboard
+const byte os_PRINTR  = 'P'           // printer
+const byte os_DISPLY  = 'S'           // screen display
+
+// SIO Command Code Equates
+
+const byte os_SIO_FORMAT   = $21      // format disk (default density)
+const byte os_SIO_FORMATS  = $22      // 1050: format medium density
+const byte os_SIO_CONFIG   = $44      // configure drive
+const byte os_SIO_CONFIGSF = $4B      // slow/fast configure drive??
+const byte os_SIO_RDPERCOM = $4E      // read PERCOM block (XF551)
+const byte os_SIO_WRPERCOM = $4F      // write PERCOM block (XF551)
+const byte os_SIO_WRITE    = $50      // write sector
+const byte os_SIO_READ     = $52      // read sector
+const byte os_SIO_STAT     = $53      // get status information
+const byte os_SIO_VERIFY   = $56      // verify sector
+const byte os_SIO_WRITEV   = $57      // write sector with verify
+const byte os_SIO_WRITETRK = $60      // write track (Speedy)
+const byte os_SIO_READTRK  = $62      // read track (Speedy)
+
+// SIO Status Code (DSTATS)
+// Input: data direction
+//     Bit #7 - W (write operation)
+//         #6 - R (read operation)
+// Output: status code
+//     $01 (001) -- OPERATION COMPLETE (NO ERRORS)
+//     $8A (138) -- DEVICE TIMEOUT (DOESN'T RESPOND)
+//     $8B (139) -- DEVICE NAK
+//     $8C (140) -- SERIAL BUS INPUT FRAMING ERROR
+//     $8E (142) -- SERIAL BUS DATA FRAME OVERRUN ERROR
+//     $8F (143) -- SERIAL BUS DATA FRAME CHECKSUM ERROR
+//     $90 (144) -- DEVICE DONE ERROR
+
+// Character and Key Code Equates
+
+const byte os_CLS     = $7D           // ##rev2## clear screen
+const byte os_EOL     = $9B           // end of line (RETURN)
+
+const byte os_HELP    = $11           // ##1200xl## key code for HELP
+const byte os_CNTLF1  = $83           // ##1200xl## key code for CTRL-F1
+const byte os_CNTLF2  = $84           // ##1200xl## key code for CTRL-F2
+const byte os_CNTLF3  = $93           // ##1200xl## key code for CTRL-F3
+const byte os_CNTLF4  = $94           // ##1200xl## key code for CTRL-F4
+const byte os_CNTL1   = $9F           // ##1200xl## key code for CTRL-1
+
+// Status Code Equates
+
+const byte os_SUCCES  = 1             // ($01) succesful operation
+
+const byte os_BRKABT  = 128           // ($80) BREAK key abort
+const byte os_PRVOPN  = 129           // ($81) IOCB already open error
+const byte os_NONDEV  = 130           // ($82) nonexistent device error
+const byte os_WRONLY  = 131           // ($83) IOCB opened for write only error
+const byte os_NVALID  = 132           // ($84) invalid command error
+const byte os_NOTOPN  = 133           // ($85) device/file not open error
+const byte os_BADIOC  = 134           // ($86) invalid IOCB index error
+const byte os_RDONLY  = 135           // ($87) IOCB opened for read only error
+const byte os_EOFERR  = 136           // ($88) end of file error
+const byte os_TRNRCD  = 137           // ($89) truncated record error
+const byte os_TIMOUT  = 138           // ($8A) peripheral device timeout error
+const byte os_DNACK   = 139           // ($8B) device does not acknowledge command
+const byte os_FRMERR  = 140           // ($8C) serial bus framing error
+const byte os_CRSROR  = 141           // ($8D) cursor overrange error
+const byte os_OVRRUN  = 142           // ($8E) serial bus data overrun error
+const byte os_CHKERR  = 143           // ($8F) serial bus checksum error
+const byte os_DERROR  = 144           // ($90) device done (operation incomplete)
+const byte os_BADMOD  = 145           // ($91) bad screen mode number error
+const byte os_FNCNOT  = 146           // ($92) function not implemented in handler
+const byte os_SCRMEM  = 147           // ($93) insufficient memory for screen mode
+const byte os_DSKFMT  = 148           // ($94) SpartaDOS: unrecognized disk format
+const byte os_INCVER  = 149           // ($95) SpartaDOS: disk was made with incompat. version
+const byte os_DIRNFD  = 150           // ($96) SpartaDOS: directory not found
+const byte os_FEXIST  = 151           // ($97) SpartaDOS: file exists
+const byte os_NOTBIN  = 152           // ($98) SpartaDOS: file not binary
+const byte os_LSYMND  = 154           // ($9A) SDX: loader symbol not defined
+const byte os_BADPRM  = 156           // ($9C) SDX: bad parameter
+const byte os_OUTOFM  = 158           // ($9E) SDX: out of memory
+const byte os_INVDEV  = 160           // ($A0) invalid device number
+const byte os_TMOF    = 161           // ($A1) too many open files
+const byte os_DSKFLL  = 162           // ($A2) disk full
+const byte os_FATLIO  = 163           // ($A3) fatal I/O error
+const byte os_FNMSMT  = 164           // ($A4) internal file number mismatch
+const byte os_INVFNM  = 165           // ($A5) invalid file name
+const byte os_PDLERR  = 166           // ($A6) point data length error
+const byte os_EPERM   = 167           // ($A7) permission denied
+const byte os_DINVCM  = 168           // ($A8) command invalid for disk
+const byte os_DIRFLL  = 169           // ($A9) directory full
+const byte os_FNTFND  = 170           // ($AA) file not found
+const byte os_PNTINV  = 171           // ($AB) point invalid
+const byte os_BADDSK  = 173           // ($AD) bad disk
+const byte os_INCFMT  = 176           // ($B0) DOS 3: incompatible file system
+const byte os_XNTBIN  = 180           // ($B4) XDOS: file not binary
+
+// DCB Device Bus Equates
+
+const byte os_DISKID  = $31           // ##rev2## disk bus ID
+const byte os_PDEVN   = $40           // ##rev2## printer bus ID
+const byte os_CASET   = $60           // ##rev2## cassette bus ID
+
+// Bus Command Equates
+
+const byte os_FOMAT   = '!'           // ##rev2## format command
+const byte os_PUTSEC  = 'P'           // ##rev2## put sector command
+const byte os_READ    = 'R'           // ##rev2## read command
+const byte os_STATC   = 'S'           // ##rev2## status command
+const byte os_WRITE   = 'W'           // ##rev2## write command
+
+// Command Auxiliary Byte Equates
+
+const byte os_DOUBLE  = 'D'           // ##rev2## print 20 characters double width
+const byte os_NORMAL  = 'N'           // ##rev2## print 40 characters normally
+const byte os_PLOT    = 'P'           // ##rev2## plot
+const byte os_SIDWAY  = 'S'           // ##rev2## print 16 characters sideways
+
+// Bus Response Equates
+
+const byte os_ACK     = 'A'           // ##rev2## device acknowledged
+const byte os_COMPLT  = 'C'           // ##rev2## device succesfully completed operation
+const byte os_ERROR   = 'E'           // ##rev2## device incurred error
+const byte os_NACK    = 'N'           // ##rev2## device did not understand
+
+// Power-up Validation Byte Value Equates
+
+const byte os_PUPVL1  = $5C           // ##rev2## power-up validation value 1
+const byte os_PUPVL2  = $93           // ##rev2## power-up validation value 2
+const byte os_PUPVL3  = $25           // ##rev2## power-up validation value 3
+
+// Relocating Loader Miscellaneous Equates
+
+const byte os_DATAER  = 156           // ##rev2## end of record appears before END
+const byte os_MEMERR  = 157           // ##rev2## memory insufficient for load error
+
+// Miscellaneous Equates
+
+const byte os_IOCFRE  = $FF           // IOCB free indication
+
+const word os_B19200  = $0028         // ##rev2## 19200 baud POKEY counter value
+const word os_B00600  = $05CC         // ##rev2## 600 baud POKEY counter value
+
+const byte os_HITONE  = $05           // ##rev2## FSK high freq. POKEY counter value
+const byte os_LOTONE  = $07           // ##rev2## FSK low freq. POKEY counter value
+
+const byte os_NCOMLO  = $34           // ##rev2## PIA lower NOT COMMAND line command
+const byte os_NCOMHI  = $3C           // ##rev2## PIA raise NOT COMMAND line command
+
+const byte os_MOTRGO  = $34           // ##rev2## PIA cassette motor ON command
+const byte os_MOTRST  = $3C           // ##rev2## PIA cassette motor OFF command
+
+const byte os_NODAT   = $00           // ##rev2## SIO immediate operation
+const byte os_GETDAT  = $40           // ##rev2## SIO read data frame
+const byte os_PUTDAT  = $80           // ##rev2## SIO write data frame
+
+const byte os_CRETRI  = 13            // ##rev2## number of command frame retries
+const byte os_DRETRI  = 1             // ##rev2## number of device retries
+const byte os_CTIM    = 2             // ##rev2## command frame ACK timeout
+
+const byte os_NBUFSZ  = 40            // ##rev2## print normal buffer size
+const byte os_DBUFSZ  = 20            // ##rev2## print double buffer size
+const byte os_SBUFSZ  = 29            // ##rev2## print sideways buffer size
+
+// ATASCII CHARACTER DEFS
+
+const byte os_ATCLR   = $7D           // CLEAR SCREEN CHARACTER
+const byte os_ATRUB   = $7E           // BACK SPACE (RUBOUT)
+const byte os_ATTAB   = $7F           // TAB
+const byte os_ATEOL   = $9B           // END-OF-LINE
+const byte os_ATDELL  = $9C           // delete line
+const byte os_ATINSL  = $9D           // insert line
+const byte os_ATCTAB  = $9E           // clear TAB
+const byte os_ATSTAB  = $9F           // set TAB
+const byte os_ATBEL   = $FD           // CONSOLE BELL
+const byte os_ATDEL   = $FE           // delete char.
+const byte os_ATINS   = $FF           // insert char.
+const byte os_ATURW   = $1C           // UP-ARROW
+const byte os_ATDRW   = $1D           // DOWN-ARROW
+const byte os_ATLRW   = $1E           // LEFT-ARROW
+const byte os_ATRRW   = $1F           // RIGHT-ARROW
+const byte os_ATESC   = $1B           // ESCAPE
+
+// Page Zero Address Equates
+
+volatile byte os_LINZBS   @$00           // LINBUG RAM (WILL BE REPLACED BY MONITOR RAM)
+volatile byte os_LNFLG    @$00           // ##1200xl## 1-LNBUG flag (0 = not LNBUG)
+volatile byte os_NGFLAG   @$01           // ##1200xl## 1-byte memory status (0 = failure)
+
+// Not Cleared
+
+volatile word os_CASINI   @$02           // CASSETTE INIT LOCATION
+volatile word os_RAMLO    @$04           // RAM POINTER FOR MEMORY TEST
+volatile byte os_TRAMSZ   @$06           // TEMPORARY REGISTER FOR RAM SIZE
+//volatile byte os_TSTDAT  @$07           // ##old## RAM TEST DATA REGISTER
+volatile byte os_CMCMD    @$07           // ##rev2## 1-byte command communications
+
+// Cleared upon Coldstart only
+
+volatile byte os_WARMST   @$08           // WARM START FLAG
+volatile byte os_BOOTQ    @$09           // SUCCESSFUL BOOT FLAG
+volatile word os_DOSVEC   @$0A           // DISK SOFTWARE START VECTOR
+volatile word os_DOSINI   @$0C           // DISK SOFTWARE INIT ADDRESS
+volatile word os_APPMHI   @$0E           // APPLICATIONS MEMORY HI LIMIT
+
+// Cleared upon Coldstart or Warmstart
+
+volatile byte os_INTZBS   @$10           // INTERRUPT HANDLER
+
+volatile byte os_POKMSK   @$10           // SYSTEM MASK FOR POKEY IRQ ENABLE (shadow of IRQEN)
+volatile byte os_BRKKEY   @$11           // BREAK KEY FLAG
+volatile int24 os_RTCLOK   @$12           // REAL TIME CLOCK (IN 16 MSEC UNITS>
+volatile word os_BUFADR   @$15           // INDIRECT BUFFER ADDRESS REGISTER
+volatile byte os_ICCOMT   @$17           // COMMAND FOR VECTOR
+volatile word os_DSKFMS   @$18           // DISK FILE MANAGER POINTER
+volatile word os_DSKUTL   @$1A           // DISK UTILITIES POINTER
+volatile byte os_ABUFPT   @$1C           // ##1200xl## 4-byte ACMI buffer pointer area
+
+//volatile byte os_PTIMOT  @$1C           // ##old## PRINTER TIME OUT REGISTER
+//volatile byte os_PBPNT   @$1D           // ##old## PRINT BUFFER POINTER
+//volatile byte os_PBUFSZ  @$1E           // ##old## PRINT BUFFER SIZE
+//volatile byte os_PTEMP   @$1F           // ##old## TEMPORARY REGISTER
+
+volatile byte os_ZIOCB    @$20           // ZERO PAGE I/O CONTROL BLOCK
+volatile byte os_IOCBAS   @$20           // 16-byte page zero IOCB
+volatile byte os_ICHIDZ   @$20           // HANDLER INDEX NUMBER (FF = IOCB FREE)
+volatile byte os_ICDNOZ   @$21           // DEVICE NUMBER (DRIVE NUMBER)
+volatile byte os_ICCOMZ   @$22           // COMMAND CODE
+volatile byte os_ICSTAZ   @$23           // STATUS OF LAST IOCB ACTION
+volatile byte os_ICBALZ   @$24           // BUFFER ADDRESS LOW BYTE
+volatile byte os_ICBAHZ   @$25           // 1-byte high buffer address
+volatile byte os_ICPTLZ   @$26           // PUT BYTE ROUTINE ADDRESS -1
+volatile byte os_ICPTHZ   @$27           // 1-byte high PUT-BYTE routine address
+volatile byte os_ICBLLZ   @$28           // BUFFER LENGTH LOW BYTE
+volatile byte os_ICBLHZ   @$29           // 1-byte high buffer length
+volatile byte os_ICAX1Z   @$2A           // AUXILIARY INFORMATION FIRST BYTE
+volatile byte os_ICAX2Z   @$2B           // 1-byte second auxiliary information
+volatile byte os_ICSPRZ   @$2C           // 4-byte spares
+
+volatile byte os_ICIDNO   @$2E           // IOCB NUMBER X 16
+volatile byte os_CIOCHR   @$2F           // CHARACTER BYTE FOR CURRENT OPERATION
+
+volatile byte os_STATUS   @$30           // INTERNAL STATUS STORAGE
+volatile byte os_CHKSUM   @$31           // CHECKSUM (SINGLE BYTE SUM WITH CARRY)
+volatile byte os_BUFRLO   @$32           // POINTER TO DATA BUFFER (LO BYTE)
+volatile byte os_BUFRHI   @$33           // POINTER TO DATA BUFFER (HI BYTE)
+volatile byte os_BFENLO   @$34           // NEXT BYTE PAST END OF THE DATA BUFFER LO
+volatile byte os_BFENHI   @$35           // NEXT BYTE PAST END OF THE DATA BUFFER HI
+//volatile byte os_CRETRY  @$36           // ##old## NUMBER OF COMMAND FRAME RETRIES
+//volatile byte os_DRETRY  @$37           // ##old## NUMBER OF DEVICE RETRIES
+volatile word os_LTEMP    @$36           // ##1200xl## 2-byte loader temporary
+volatile byte os_BUFRFL   @$38           // DATA BUFFER FULL FLAG
+volatile byte os_RECVDN   @$39           // RECEIVE DONE FLAG
+volatile byte os_XMTDON   @$3A           // TRANSMISSION DONE FLAG
+volatile byte os_CHKSNT   @$3B           // CHECKSUM SENT FLAG
+volatile byte os_NOCKSM   @$3C           // NO CHECKSUM FOLLOWS DATA FLAG
+volatile byte os_BPTR     @$3D           // 1-byte cassette buffer pointer
+volatile byte os_FTYPE    @$3E           // 1-byte cassette IRG type
+volatile byte os_FEOF     @$3F           // 1-byte cassette EOF flag (0 = quiet)
+volatile byte os_FREQ     @$40           // 1-byte cassette beep counter
+volatile byte os_SOUNDR   @$41           // NOISY I/0 FLAG. (ZERO IS QUIET)
+
+volatile byte os_CRITIC   @$42           // DEFINES CRITICAL SECTION (CRITICAL IF NON-Z)
+
+volatile byte os_FMSZPG   @$43           // DISK FILE MANAGER SYSTEM ZERO PAGE
+volatile word os_ZBUFP    @$43			 // Buffer pointer to the user filename for disk I/O.
+volatile word os_ZDRVA    @$45           // Driver pointer
+volatile word os_ZSBA     @$47           // Sector buffer pointer
+volatile byte os_ERRNO    @$49           // Disk I/O error number. Initialized to $9F by FMS.
+
+//volatile byte os_CKEY    @$4A           // ##old## FLAG SET WHEN GAME START PRESSED
+volatile word os_ZCHAIN   @$4A           // ##1200xl## 2-byte handler linkage chain pointer
+//volatile byte os_CASSBT  @$4B           // ##old## CASSETTE BOOT FLAG
+volatile byte os_DSTAT    @$4C           // DISPLAY STATUS
+volatile byte os_ATRACT   @$4D           // ATRACT FLAG
+volatile byte os_DRKMSK   @$4E           // DARK ATRACT MASK
+volatile byte os_COLRSH   @$4F           // ATRACT COLOR SHIFTER (EOR'ED WITH PLAYFIELD
+
+volatile byte os_TMPCHR   @$50           // 1-byte temporary character
+volatile byte os_HOLD1    @$51           // 1-byte temporary
+volatile byte os_LMARGN   @$52           // left margin (default 2)
+volatile byte os_RMARGN   @$53           // right margin (default 39 if no XEP80 is used)
+volatile byte os_ROWCRS   @$54           // 1-byte cursor row
+volatile word os_COLCRS   @$55           // 2-byte cursor column
+volatile byte os_DINDEX   @$57           // 1-byte display mode
+volatile word os_SAVMSC   @$58           // 2-byte saved memory scan counter
+volatile byte os_OLDROW   @$5A           // 1-byte prior row
+volatile word os_OLDCOL   @$5B           // 2-byte prior column
+volatile byte os_OLDCHR   @$5D           // DATA UNDER CURSOR
+volatile word os_OLDADR   @$5E           // 2-byte saved cursor memory address
+volatile word os_FKDEF    @$60           // ##1200xl## 2-byte function key definition table
+//volatile byte os_NEWROW  @$60           // ##old## POINT DRAW GOES TO
+//volatile word os_NEWCOL  @$61           // ##old##
+volatile byte os_PALNTS   @$62           // ##1200xl## 1-byte PAL/NTSC indicator (0 = NTSC)
+volatile byte os_LOGCOL   @$63           // POINTS AT COLUMN IN LOGICAL LINE
+volatile word os_ADRESS   @$64           // 2-byte temporary address
+
+volatile byte os_MLTTMP   @$66           // 1-byte temporary
+volatile byte os_OPNTMP   @$66           // FIRST BYTE IS USED IN OPEN AS TEMP
+volatile word os_TOADR    @$66           // ##rev2## 2-byte destination address
+
+volatile word os_SAVADR   @$68           // 2-byte saved address
+volatile word os_FRMADR   @$68           // ##rev2## 2-byte source address
+
+volatile byte os_RAMTOP   @$6A           // RAM SIZE DEFINED BY POWER ON LOGIC
+volatile byte os_BUFCNT   @$6B           // BUFFER COUNT
+volatile word os_BUFSTR   @$6C           // EDITOR GETCH POINTER
+volatile byte os_BITMSK   @$6E           // BIT MASK
+volatile byte os_SHFAMT   @$6F           // 1-byte shift amount for pixel justifucation
+volatile word os_ROWAC    @$70           // 2-byte draw working row
+volatile word os_COLAC    @$72           // 2-byte draw working column
+volatile word os_ENDPT    @$74           // 2-byte end point
+volatile byte os_DELTAR   @$76           // 1-byte row difference
+volatile word os_DELTAC   @$77           // 2-byte column difference
+volatile word os_KEYDEF   @$79           // ##1200xl## 2-byte key definition table address
+//volatile byte os_ROWINC  @$79           // ##old##
+//volatile byte os_COLINC  @$7A           // ##old##
+volatile byte os_SWPFLG   @$7B           // NON-0 IF TXT AND REGULAR RAM IS SWAPPED
+volatile byte os_HOLDCH   @$7C           // CH IS MOVED HERE IN KGETCH BEFORE CNTL & SH
+volatile byte os_INSDAT   @$7D           // 1-byte temporary
+volatile word os_COUNTR   @$7E           // 2-byte draw iteration count
+
+// Page Two Address Equates
+
+volatile word os_INTABS @$0200         // INTERRUPT RAM
+volatile word os_VDSLST @$0200         // DISPLAY LIST NMI VECTOR
+volatile word os_VPRCED @$0202         // PROCEED LINE IRQ VECTOR
+volatile word os_VINTER @$0204         // INTERRUPT LINE IRQ VECTOR
+volatile word os_VBREAK @$0206         // SOFTWARE BREAK (00) INSTRUCTION IRQ VECTOR
+volatile word os_VKEYBD @$0208         // POKEY KEYBOARD IRQ VECTOR
+volatile word os_VSERIN @$020A         // POKEY SERIAL INPUT READY IRQ
+volatile word os_VSEROR @$020C         // POKEY SERIAL OUTPUT READY IRQ
+volatile word os_VSEROC @$020E         // POKEY SERIAL OUTPUT COMPLETE IRQ
+volatile word os_VTIMR1 @$0210         // POKEY TIMER 1 IRQ
+volatile word os_VTIMR2 @$0212         // POKEY TIMER 2 IRQ
+volatile word os_VTIMR4 @$0214         // POKEY TIMER 4 IRQ
+volatile word os_VIMIRQ @$0216         // IMMEDIATE IRQ VECTOR
+volatile word os_CDTMV1 @$0218         // COUNT DOWN TIMER 1
+volatile word os_CDTMV2 @$021A         // COUNT DOWN TIMER 2
+volatile word os_CDTMV3 @$021C         // COUNT DOWN TIMER 3
+volatile word os_CDTMV4 @$021E         // COUNT DOWN TIMER 4
+volatile word os_CDTMV5 @$0220         // COUNT DOWN TIMER 5
+volatile word os_VVBLKI @$0222         // IMMEDIATE VERTICAL BLANK NMI VECTOR
+volatile word os_VVBLKD @$0224         // DEFERRED VERTICAL BLANK NMI VECTOR
+volatile word os_CDTMA1 @$0226         // COUNT DOWN TIMER 1 JSR ADDRESS
+volatile word os_CDTMA2 @$0228         // COUNT DOWN TIMER 2 JSR ADDRESS
+volatile byte os_CDTMF3 @$022A         // COUNT DOWN TIMER 3 FLAG
+volatile byte os_SRTIMR @$022B         // SOFTWARE REPEAT TIMER
+volatile byte os_CDTMF4 @$022C         // COUNT DOWN TIMER 4 FLAG
+volatile byte os_INTEMP @$022D         // IAN'S TEMP
+volatile byte os_CDTMF5 @$022E         // COUNT DOWN TIMER FLAG 5
+volatile byte os_SDMCTL @$022F         // SAVE DMACTL REGISTER
+volatile byte os_SDLSTL @$0230         // SAVE DISPLAY LIST LOW BYTE
+volatile byte os_SDLSTH @$0231         // SAVE DISPLAY LIST HI BYTE
+volatile byte os_SSKCTL @$0232         // SKCTL REGISTER RAM
+volatile byte os_LCOUNT @$0233         // ##1200xl## 1-byte relocating loader record
+volatile byte os_LPENH  @$0234         // LIGHT PEN HORIZONTAL VALUE
+volatile byte os_LPENV  @$0235         // LIGHT PEN VERTICAL VALUE
+volatile word os_BRKKY  @$0236         // BREAK KEY VECTOR
+//volatile word os_RELADR @$0238         // ##1200xl## 2-byte relocatable loader address
+volatile word os_VPIRQ  @$0238         // ##rev2## 2-byte parallel device IRQ vector
+volatile byte os_CDEVIC @$023A         // COMMAND FRAME BUFFER - DEVICE
+volatile byte os_CCOMND @$023B         // COMMAND
+volatile byte os_CAUX1  @$023C         // COMMAND AUX BYTE 1
+volatile byte os_CAUX2  @$023D         // COMMAND AUX BYTE 2
+
+volatile byte os_TEMP   @$023E         // TEMPORARY RAM CELL
+
+volatile byte os_ERRFLG @$023F         // ERROR FLAG - ANY DEVICE ERROR EXCEPT TIME OUT
+
+volatile byte os_DFLAGS @$0240         // DISK FLAGS FROM SECTOR ONE
+volatile byte os_DBSECT @$0241         // NUMBER OF DISK BOOT SECTORS
+volatile word os_BOOTAD @$0242         // ADDRESS WHERE DISK BOOT LOADER WILL BE PUT
+volatile byte os_COLDST @$0244         // COLDSTART FLAG (1=IN MIDDLE OF COLDSTART>
+volatile byte os_RECLEN @$0245         // ##1200xl## 1-byte relocating loader record length
+volatile byte os_DSKTIM @$0246         // DISK TIME OUT REGISTER
+//volatile byte os_LINBUF @$0247         // ##old## CHAR LINE BUFFER
+
+volatile byte os_PDVMSK @$0247         // ##rev2## 1-byte parallel device selection mask
+volatile byte os_SHPDVS @$0248         // ##rev2## 1-byte PDVS (parallel device select)
+volatile byte os_PDIMSK @$0249         // ##rev2## 1-byte parallel device IRQ selection
+volatile word os_RELADR @$024A         // ##rev2## 2-byte relocating loader relative adr.
+volatile byte os_PPTMPA @$024C         // ##rev2## 1-byte parallel device handler temporary
+volatile byte os_PPTMPX @$024D         // ##rev2## 1-byte parallel device handler temporary
+
+volatile byte os_CHSALT @$026B         // ##1200xl## 1-byte character set alternate
+volatile byte os_VSFLAG @$026C         // ##1200xl## 1-byte fine vertical scroll count
+volatile byte os_KEYDIS @$026D         // ##1200xl## 1-byte keyboard disable
+volatile byte os_FINE   @$026E         // ##1200xl## 1-byte fine scrolling mode
+volatile byte os_GPRIOR @$026F         // GLOBAL PRIORITY CELL
+
+volatile byte os_PADDL0 @$0270         // 1-byte potentiometer 0
+volatile byte os_PADDL1 @$0271         // 1-byte potentiometer 1
+volatile byte os_PADDL2 @$0272         // 1-byte potentiometer 2
+volatile byte os_PADDL3 @$0273         // 1-byte potentiometer 3
+volatile byte os_PADDL4 @$0274         // 1-byte potentiometer 4
+volatile byte os_PADDL5 @$0275         // 1-byte potentiometer 5
+volatile byte os_PADDL6 @$0276         // 1-byte potentiometer 6
+volatile byte os_PADDL7 @$0277         // 1-byte potentiometer 7
+
+volatile byte os_STICK0 @$0278         // 1-byte joystick 0
+volatile byte os_STICK1 @$0279         // 1-byte joystick 1
+volatile byte os_STICK2 @$027A         // 1-byte joystick 2
+volatile byte os_STICK3 @$027B         // 1-byte joystick 3
+
+volatile byte os_PTRIG0 @$027C         // 1-byte paddle trigger 0
+volatile byte os_PTRIG1 @$027D         // 1-byte paddle trigger 1
+volatile byte os_PTRIG2 @$027E         // 1-byte paddle trigger 2
+volatile byte os_PTRIG3 @$027F         // 1-byte paddle trigger 3
+volatile byte os_PTRIG4 @$0280         // 1-byte paddle trigger 4
+volatile byte os_PTRIG5 @$0281         // 1-byte paddle trigger 5
+volatile byte os_PTRIG6 @$0281         // 1-byte paddle trigger 6
+volatile byte os_PTRIG7 @$0283         // 1-byte paddle trigger 7
+
+volatile byte os_STRIG0 @$0284         // 1-byte joystick trigger 0
+volatile byte os_STRIG1 @$0285         // 1-byte joystick trigger 1
+volatile byte os_STRIG2 @$0286         // 1-byte joystick trigger 2
+volatile byte os_STRIG3 @$0287         // 1-byte joystick trigger 3
+
+//volatile byte os_CSTAT @$0288         // ##old## cassette status register
+volatile byte os_HIBYTE @$0288         // ##1200xl## 1-byte relocating loader high byte
+volatile byte os_WMODE  @$0289         // 1-byte cassette WRITE mode
+volatile byte os_BLIM   @$028A         // 1-byte cassette buffer limit
+volatile byte os_IMASK  @$028B         // ##rev2## (not used)
+volatile word os_JVECK  @$028C         // 2-byte jump vector or temporary
+volatile word os_NEWADR @$028E         // ##1200xl## 2-byte relocating address
+volatile byte os_TXTROW @$0290         // TEXT ROWCRS
+volatile word os_TXTCOL @$0291         // TEXT COLCRS
+volatile byte os_TINDEX @$0293         // TEXT INDEX
+volatile byte os_TXTMSC @$0294         // FOOLS CONVRT INTO NEW MSC
+volatile byte os_TXTOLD @$0296         // OLDROW & OLDCOL FOR TEXT (AND THEN SOME)
+//volatile byte os_TMPX1 @$029C         // ##old## 1-byte temporary register
+volatile byte os_CRETRY @$029C         // ##1200xl## 1-byte number of command frame retries
+volatile byte os_HOLD3  @$029D         // 1-byte temporary
+volatile byte os_SUBTMP @$029E         // 1-byte temporary
+volatile byte os_HOLD2  @$029F         // 1-byte (not used)
+volatile byte os_DMASK  @$02A0         // 1-byte display (pixel location) mask
+volatile byte os_TMPLBT @$02A1         // 1-byte (not used)
+volatile byte os_ESCFLG @$02A2         // ESCAPE FLAG
+volatile byte os_TABMAP @$02A3         // 15-byte (120 bit) tab stop bit map
+volatile byte os_LOGMAP @$02B2         // LOGICAL LINE START BIT MAP
+volatile byte os_INVFLG @$02B6         // INVERSE VIDEO FLAG (TOGGLED BY ATARI KEY)
+volatile byte os_FILFLG @$02B7         // RIGHT FILL FLAG FOR DRAW
+volatile byte os_TMPROW @$02B8         // 1-byte temporary row
+volatile word os_TMPCOL @$02B9         // 2-byte temporary column
+volatile byte os_SCRFLG @$02BB         // SET IF SCROLL OCCURS
+volatile byte os_HOLD4  @$02BC         // TEMP CELL USED IN DRAW ONLY
+//volatile byte os_HOLD5  @$02BD         // ##old## DITTO
+volatile byte os_DRETRY @$02BD         // ##1200xl## 1-byte number of device retries
+volatile byte os_SHFLOK @$02BE         // 1-byte shift/control lock flags
+volatile byte os_BOTSCR @$02BF         // BOTTOM OF SCREEN   24 NORM 4 SPLIT
+
+volatile byte os_PCOLR0 @$02C0         // 1-byte player-missile 0 color/luminance
+volatile byte os_PCOLR1 @$02C1         // 1-byte player-missile 1 color/luminance
+volatile byte os_PCOLR2 @$02C2         // 1-byte player-missile 2 color/luminance
+volatile byte os_PCOLR3 @$02C3         // 1-byte player-missile 3 color/luminance
+
+volatile byte os_COLOR0 @$02C4         // 1-byte playfield 0 color/luminance
+volatile byte os_COLOR1 @$02C5         // 1-byte playfield 1 color/luminance
+volatile byte os_COLOR2 @$02C6         // 1-byte playfield 2 color/luminance
+volatile byte os_COLOR3 @$02C7         // 1-byte playfield 3 color/luminance
+
+volatile byte os_COLOR4 @$02C8         // 1-byte background color/luminance
+
+volatile byte os_PARMBL @$02C9         // ##rev2## 6-byte relocating loader parameter
+volatile word os_RUNADR @$02C9         // ##1200xl## 2-byte run address
+volatile word os_HIUSED @$02CB         // ##1200xl## 2-byte highest non-zero page address
+volatile word os_ZHIUSE @$02CD         // ##1200xl## 2-byte highest zero page address
+
+volatile byte os_OLDPAR @$02CF         // ##rev2## 6-byte relocating loader parameter
+volatile word os_GBYTEA @$02CF         // ##1200xl## 2-byte GET-BYTE routine address
+volatile word os_LOADAD @$02D1         // ##1200xl## 2-byte non-zero page load address
+volatile word os_ZLOADA @$02D3         // ##1200xl## 2-byte zero page load address
+
+volatile word os_DSCTLN @$02D5         // ##1200xl## 2-byte disk sector length
+volatile word os_ACMISR @$02D7         // ##1200xl## 2-byte ACMI interrupt service routine
+volatile byte os_KRPDEL @$02D9         // ##1200xl## 1-byte auto-repeat delay
+volatile byte os_KEYREP @$02DA         // ##1200xl## 1-byte auto-repeat rate
+volatile byte os_NOCLIK @$02DB         // ##1200xl## 1-byte key click disable
+volatile byte os_HELPFG @$02DC         // ##1200xl## 1-byte HELP key flag (0 = no HELP)
+volatile byte os_DMASAV @$02DD         // ##1200xl## 1-byte SDMCTL save/restore
+volatile byte os_PBPNT  @$02DE         // ##1200xl## 1-byte printer buffer pointer
+volatile byte os_PBUFSZ @$02DF         // ##1200xl## 1-byte printer buffer size
+
+volatile byte os_GLBABS @$02E0         // 4-byte global variables for non-DOS users
+volatile word os_RUNAD  @$02E0         // ##map## 2-byte binary file run address
+volatile word os_INITAD @$02E2         // ##map## 2-byte binary file initialization address
+
+volatile byte os_RAMSIZ @$02E4         // RAM SIZE (HI BYTE ONLY)
+volatile word os_MEMTOP @$02E5         // TOP OF AVAILABLE USER MEMORY
+volatile word os_MEMLO  @$02E7         // BOTTOM OF AVAILABLE USER MEMORY
+volatile byte os_HNDLOD @$02E9         // ##1200xl## 1-byte user load flag
+volatile byte os_DVSTAT @$02EA         // STATUS BUFFER
+volatile byte os_CBAUDL @$02EE         // 1-byte low cassette baud rate
+volatile byte os_CBAUDH @$02EF         // 1-byte high cassette baud rate
+volatile byte os_CRSINH @$02F0         // CURSOR INHIBIT (00 = CURSOR ON)
+volatile byte os_KEYDEL @$02F1         // KEY DELAY
+volatile byte os_CH1    @$02F2         // 1-byte prior keyboard character
+volatile byte os_CHACT  @$02F3         // CHACTL REGISTER RAM
+volatile byte os_CHBAS  @$02F4         // CHBAS REGISTER RAM
+
+volatile byte os_NEWROW @$02F5         // ##1200xl## 1-byte draw destination row
+volatile word os_NEWCOL @$02F6         // ##1200xl## 2-byte draw destination column
+volatile byte os_ROWINC @$02F8         // ##1200xl## 1-byte draw row increment
+volatile byte os_COLINC @$02F9         // ##1200xl## 1-byte draw column increment
+
+volatile byte os_CHAR   @$02FA         // 1-byte internal character
+volatile byte os_ATACHR @$02FB         // ATASCII CHARACTER
+volatile byte os_CH     @$02FC         // GLOBAL VARIABLE FOR KEYBOARD
+volatile byte os_FILDAT @$02FD         // RIGHT FILL DATA <DRAW>
+volatile byte os_DSPFLG @$02FE         // DISPLAY FLAG   DISPLAY CNTLS IF NON-ZERO
+volatile byte os_SSFLAG @$02FF         // START/STOP FLAG FOR PAGING (CNTL 1). CLEARE
+
+// Page Three Address Equates
+
+volatile byte os_DCB    @$0300         // DEVICE CONTROL BLOCK
+volatile byte os_DDEVIC @$0300         // PERIPHERAL UNIT 1 BUS I.D. NUMBER
+volatile byte os_DUNIT  @$0301         // UNIT NUMBER
+volatile byte os_DCOMND @$0302         // BUS COMMAND
+volatile byte os_DSTATS @$0303         // COMMAND TYPE/STATUS RETURN
+volatile byte os_DBUFLO @$0304         // 1-byte low data buffer address
+volatile byte os_DBUFHI @$0305         // 1-byte high data buffer address
+volatile byte os_DTIMLO @$0306         // DEVICE TIME OUT IN 1 SECOND UNITS
+volatile byte os_DUNUSE @$0307         // UNUSED BYTE
+volatile byte os_DBYTLO @$0308         // 1-byte low number of bytes to transfer
+volatile byte os_DBYTHI @$0309         // 1-byte high number of bytes to transfer
+volatile byte os_DAUX1  @$030A         // 1-byte first command auxiliary
+volatile byte os_DAUX2  @$030B         // 1-byte second command auxiliary
+
+volatile word os_TIMER1 @$030C         // INITIAL TIMER VALUE
+//volatile byte os_ADDCOR @$030E         // ##old## ADDITION CORRECTION
+volatile byte os_JMPERS @$030E         // ##1200xl## 1-byte jumper options
+volatile byte os_CASFLG @$030F         // CASSETTE MODE WHEN SET
+volatile word os_TIMER2 @$0310         // 2-byte final baud rate timer value
+volatile word os_TEMP1  @$0312         // TEMPORARY STORAGE REGISTER
+//volatile byte os_TEMP2  @$0314         // ##old## TEMPORARY STORAGE REGISTER
+volatile byte os_TEMP2  @$0313         // ##1200xl## 1-byte temporary
+volatile byte os_PTIMOT @$0314         // ##1200xl## 1-byte printer timeout
+volatile byte os_TEMP3  @$0315         // TEMPORARY STORAGE REGISTER
+volatile byte os_SAVIO  @$0316         // SAVE SERIAL IN DATA PORT
+volatile byte os_TIMFLG @$0317         // TIME OUT FLAG FOR BAUD RATE CORRECTION
+volatile byte os_STACKP @$0318         // SIO STACK POINTER SAVE CELL
+volatile byte os_TSTAT  @$0319         // TEMPORARY STATUS HOLDER
+
+volatile byte os_HATABS @$031A         // 35-byte handler address table (was 38 bytes)
+volatile byte os_PUPBT1 @$033D         // ##1200xl## 1-byte power-up validation byte 1
+volatile byte os_PUPBT2 @$033E         // ##1200xl## 1-byte power-up validation byte 2
+volatile byte os_PUPBT3 @$033F         // ##1200xl## 1-byte power-up validation byte 3
+
+// I/O CONTROL BLOCKS
+
+volatile byte os_IOCB0  @$0340
+volatile byte os_IOCB1  @$0350
+volatile byte os_IOCB2  @$0360
+volatile byte os_IOCB3  @$0370
+volatile byte os_IOCB4  @$0380
+volatile byte os_IOCB5  @$0390
+volatile byte os_IOCB6  @$03A0
+volatile byte os_IOCB7  @$03B0
+
+volatile byte os_PRNBUF @$03C0         // PRINTER BUFFER
+volatile byte os_SUPERF @$03E8         // ##1200xl## 1-byte editor super function flag
+volatile byte os_CKEY   @$03E9         // ##1200xl## 1-byte cassette boot request flag
+volatile byte os_CASSBT @$03EA         // ##1200xl## 1-byte cassette boot flag
+volatile byte os_CARTCK @$03EB         // ##1200xl## 1-byte cartridge equivalence check
+volatile byte os_DERRF  @$03EC         // ##rev2## 1-byte screen OPEN error flag
+
+// Remainder of Page Three Not Cleared upon Reset
+
+volatile byte os_ACMVAR @$03ED         // ##1200xl## 11 bytes reserved for ACMI
+volatile byte os_BASICF @$03F8         // ##rev2## 1-byte BASIC switch flag
+volatile byte os_MINTLK @$03F9         // ##1200xl## 1-byte ACMI module interlock
+volatile byte os_GINTLK @$03FA         // ##1200xl## 1-byte cartridge interlock
+volatile word os_CHLINK @$03FB         // ##1200xl## 2-byte loaded handler chain link
+volatile byte os_CASBUF @$03FD         // CASSETTE BUFFER
+
+// Page Four/Five Address Equates
+
+// USER AREA STARTS HERE AND GOES TO END OF PAGE FIVE
+volatile byte os_USAREA @$0480         // 128 bytes reserved for application
+
+volatile byte os_LBPR1  @$057E         // LBUFF PREFIX 1
+volatile byte os_LBPR2  @$057F         // LBUFF PREFIX 2
+volatile byte os_LBUFF  @$0580         // 128-byte line buffer
+
+//volatile byte os_LBFEND @$05FF         // ##old## END OF LBUFF
+
+volatile byte os_INIML  @$0700         // ##rev2## initial MEMLO
+
+// Cartridge Address Equates
+
+volatile word os_CARTCS @$BFFA         // ##rev2## 2-byte cartridge coldstart address
+volatile byte os_CART   @$BFFC         // ##rev2## 1-byte cartridge present indicator
+						               // 0=Cart Exists
+volatile byte os_CARTFG @$BFFD         // ##rev2## 1-byte cartridge flags
+                                       // D7  0=Not a Diagnostic Cart
+                                       //     1=Is a Diagnostic cart and control is
+                                       //       given to cart before any OS is init.
+                                       // D2  0=Init but Do not Start Cart
+                                       //     1=Init and Start Cart
+                                       // D0  0=Do not boot disk
+                                       //     1=Boot Disk
+volatile word os_CARTAD @$BFFE         // ##rev2## 2-byte cartridge start vector
+
+// Character sets
+
+const byte os_ICSORG = $CC00             // ##rev2## international character set origin
+const byte os_DCSORG = $E000             // ##rev2## domestic character set origin
+
+// Device Handler Vector Table Address Equates
+
+const byte os_EDITRV = $E400         // editor handler vector table
+const byte os_SCRENV = $E410         // screen handler vector table
+const byte os_KEYBDV = $E420         // keyboard handler vector table
+const byte os_PRINTV = $E430         // printer handler vector table
+const byte os_CASETV = $E440         // cassette handler vector table
+
+// Jump Vector Address Equates
+
+const byte os_DISKIV = $E450         // vector to initialize DIO
+const byte os_DSKINV = $E453         // vector to DIO
+const byte os_CIOV   = $E456         // vector to CIO
+const byte os_SIOV   = $E459         // vector to SIO
+
+const byte os_SETVBV = $E45C         // vector to set VBLANK parameters
+const byte os_SYSVBV = $E45F         // vector to process immediate VBLANK
+const byte os_XITVBV = $E462         // vector to process deferred VBLANK
+
+const byte os_SIOINV = $E465         // vector to initialize SIO
+const byte os_SENDEV = $E468         // vector to enable SEND
+const byte os_INTINV = $E46B         // vector to initialize interrupt handler
+const byte os_CIOINV = $E46E         // vector to initialize CIO
+
+const byte os_BLKBDV = $E471         // vector to power-up display
+const byte os_WARMSV = $E474         // vector to warmstart
+const byte os_COLDSV = $E477         // vector to coldstart
+
+const byte os_RBLOKV = $E47A         // vector to read cassette block
+const byte os_CSOPIV = $E47D         // vector to open cassette for input
+
+const byte os_VCTABL = $E480         // RAM vector initial value table
+const byte os_PUPDIV = $E480         // ##rev2## vector to power-up display
+const byte os_SLFTSV = $E483         // ##rev2## vector to self-test
+const byte os_PHENTV = $E486         // ##rev2## vector to enter peripheral handler
+const byte os_PHUNLV = $E489         // ##rev2## vector to unlink peripheral handler
+const byte os_PHINIV = $E48C         // ##rev2## vector to initialize peripheral handler
+const byte os_GPDVV  = $E48F         // ##rev2## generic parallel device handler vector
+
+// 6502
+
+const byte os_NMIVEC = $FFFA
+const byte os_RESVEC = $FFFC
+const byte os_IRQVEC = $FFFE


### PR DESCRIPTION
Hi,

I've added most of the labels for the A8 Operating System.

There are still a few things I want to add in separate modules:
- floating point
- BASIC
- PBI
- DOS
...

I like to suggest adding separate folders for each target in the "include" folder. What do you think?