### PR TITLE
Fix cia_disable_irq macro.

### DIFF
--- a/include/c64_cia.mfk
+++ b/include/c64_cia.mfk
@@ -16,8 +16,8 @@ byte cia2_ddrb      @$DD03
 
 macro asm void cia_disable_irq() {
     ? LDA #$7f
-    ! LDA $dc0d
-    ! LDA $dd0d
+    ! STA $dc0d
+    ! STA $dd0d
     ! LDA $dc0d
     ! LDA $dd0d
 }


### PR DESCRIPTION
I'm fairly sure this is the correct sequence of instructions to disable irq - tested in my own project. The original macro didn't work for me.