### PR TITLE
Add voice 3 oscillator and ADSR output registers.

### DIFF
--- a/include/c64_sid.mfk
+++ b/include/c64_sid.mfk
@@ -30,3 +30,6 @@ byte sid_filt_mode @$D418
 
 volatile byte sid_paddle_x @$D419
 volatile byte sid_paddle_y @$D41A
+
+volatile byte sid_v3_osc_out @D41B
+volatile byte sid_v3_adsr_out @D41C


### PR DESCRIPTION
These registers can be used for reading the instantaneous output value of the oscillator and ADSR envelope from voice 3 of the SID.