### PR TITLE
Improved #36: Added compile flags for enabling tests

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -21,28 +21,11 @@ Setting up the test suite for Millfork is tricky, so if you don't need the tests
 
 #### Steps
 
-* remove all test dependencies from `build.sbt`: 
-
-      "org.scalatest" %% "scalatest"
-      "com.codingrodent.microprocessor" % "Z80Processor"
-      "NeatMonster" % "Intel8086"
-      "com.loomcom.symon" % "symon"
-      "com.grapeshot" % "halfnes"
-      "eu.rekawek.coffeegb" % "coffee-gb"
-      "roug.org.osnine" % "osnine-core"
-
-* navigate to the project directory 
-
-* run `sbt 'set test in assembly := {}' compile`  
+* run `sbt compile`  
 to compile the project
 
-* run `sbt 'set test in assembly := {}' assembly`  
+* run `sbt assembly`  
 to build the executable jar file, it should appear in `target/scala-2.12`
-
-* on Windows, use double quotes for the last two commands:
-
-      sbt "set test in assembly := {}" compile
-      sbt "set test in assembly := {}" assembly
 
 ### Building with tests
 
@@ -72,9 +55,9 @@ Test suite is useful if you plan on modifying the compiler. Some test dependenci
 
 * navigate to the project directory 
 
-* run `sbt compile` to compile the project
+* run `sbt -DincludeTests compile` to compile the project
 
-* run `sbt assemble` to build the executable jar file, it should appear in `target/scala-2.12`
+* run `sbt -DincludeTests assemble` to build the executable jar file, it should appear in `target/scala-2.12`
 
 ### Building a native executable
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,36 +12,41 @@ libraryDependencies += "org.apache.commons" % "commons-configuration2" % "2.2"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 
-libraryDependencies += "com.codingrodent.microprocessor" % "Z80Processor" % "2.0.2" % "test"
-
-if (System.getProperty("includeTests") != null) {
-  println("Including test dependencies")
+val testDependencies = Seq(
+  "com.codingrodent.microprocessor" % "Z80Processor" % "2.0.2" % "test",
   // see: https://github.com/NeatMonster/Intel8086
-  libraryDependencies += "NeatMonster" % "Intel8086" % "1.0" % "test" from "https://github.com/NeatMonster/Intel8086/raw/master/IBMPC.jar"
-
+  "NeatMonster" % "Intel8086" % "1.0" % "test" from "https://github.com/NeatMonster/Intel8086/raw/master/IBMPC.jar",
   // these three are not in Maven Central or any other public repo
   // get them from the following links or just build millfork without tests:
   // https://github.com/sethm/symon/tree/71905fdb1998ee4f142260879504bc46cf27648f
   // https://github.com/andrew-hoffman/halfnes/tree/061
   // https://github.com/trekawek/coffee-gb/tree/coffee-gb-1.0.0
   // https://github.com/sorenroug/osnine-java/tree/b77349a6c314e1362e69b7158c385ac6f89b7ab8
+  "com.loomcom.symon" % "symon" % "1.3.0-SNAPSHOT" % "test",
+  "com.grapeshot" % "halfnes" % "061" % "test",
+  "eu.rekawek.coffeegb" % "coffee-gb" % "1.0.0" % "test",
+  "roug.org.osnine" % "osnine-core" % "2.0-SNAPSHOT" % "test",
+  "org.graalvm.sdk" % "graal-sdk" % "20.2.0" % "test",
+  "org.graalvm.js" % "js" % "20.2.0" % "test",
+  "org.graalvm.js" % "js-scriptengine" % "20.2.0" % "test"
+)
 
-  libraryDependencies += "com.loomcom.symon" % "symon" % "1.3.0-SNAPSHOT" % "test"
+val includesTests = System.getProperty("includeTests") != null
 
-  libraryDependencies += "com.grapeshot" % "halfnes" % "061" % "test"
+libraryDependencies ++=(
+  if (includesTests) {
+    println("Including test dependencies")
+    testDependencies
+  } else {
+    Seq()
+  }
+)
 
-  libraryDependencies += "eu.rekawek.coffeegb" % "coffee-gb" % "1.0.0" % "test"
-
-  libraryDependencies += "roug.org.osnine" % "osnine-core" % "2.0-SNAPSHOT" % "test"
-
-  libraryDependencies += "org.graalvm.sdk" % "graal-sdk" % "20.2.0" % "test"
-
-  libraryDependencies += "org.graalvm.js" % "js" % "20.2.0" % "test"
-
-  libraryDependencies += "org.graalvm.js" % "js-scriptengine" % "20.2.0" % "test"
-} else {
+(if (!includesTests) {
+  // Disable assembling tests
   test in assembly := {}
-}
+  // SBT doesn't like returning Unit, so return Seq
+} else Seq())
 
 mainClass in Compile := Some("millfork.Main")
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,29 +14,34 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 
 libraryDependencies += "com.codingrodent.microprocessor" % "Z80Processor" % "2.0.2" % "test"
 
-// see: https://github.com/NeatMonster/Intel8086
-libraryDependencies += "NeatMonster" % "Intel8086" % "1.0" % "test" from "https://github.com/NeatMonster/Intel8086/raw/master/IBMPC.jar"
+if (System.getProperty("includeTests") != null) {
+  println("Including test dependencies")
+  // see: https://github.com/NeatMonster/Intel8086
+  libraryDependencies += "NeatMonster" % "Intel8086" % "1.0" % "test" from "https://github.com/NeatMonster/Intel8086/raw/master/IBMPC.jar"
 
-// these three are not in Maven Central or any other public repo
-// get them from the following links or just build millfork without tests:
-// https://github.com/sethm/symon/tree/71905fdb1998ee4f142260879504bc46cf27648f
-// https://github.com/andrew-hoffman/halfnes/tree/061
-// https://github.com/trekawek/coffee-gb/tree/coffee-gb-1.0.0
-// https://github.com/sorenroug/osnine-java/tree/b77349a6c314e1362e69b7158c385ac6f89b7ab8
+  // these three are not in Maven Central or any other public repo
+  // get them from the following links or just build millfork without tests:
+  // https://github.com/sethm/symon/tree/71905fdb1998ee4f142260879504bc46cf27648f
+  // https://github.com/andrew-hoffman/halfnes/tree/061
+  // https://github.com/trekawek/coffee-gb/tree/coffee-gb-1.0.0
+  // https://github.com/sorenroug/osnine-java/tree/b77349a6c314e1362e69b7158c385ac6f89b7ab8
 
-libraryDependencies += "com.loomcom.symon" % "symon" % "1.3.0-SNAPSHOT" % "test"
+  libraryDependencies += "com.loomcom.symon" % "symon" % "1.3.0-SNAPSHOT" % "test"
 
-libraryDependencies += "com.grapeshot" % "halfnes" % "061" % "test"
+  libraryDependencies += "com.grapeshot" % "halfnes" % "061" % "test"
 
-libraryDependencies += "eu.rekawek.coffeegb" % "coffee-gb" % "1.0.0" % "test"
+  libraryDependencies += "eu.rekawek.coffeegb" % "coffee-gb" % "1.0.0" % "test"
 
-libraryDependencies += "roug.org.osnine" % "osnine-core" % "2.0-SNAPSHOT" % "test"
+  libraryDependencies += "roug.org.osnine" % "osnine-core" % "2.0-SNAPSHOT" % "test"
 
-libraryDependencies += "org.graalvm.sdk" % "graal-sdk" % "20.2.0" % "test"
+  libraryDependencies += "org.graalvm.sdk" % "graal-sdk" % "20.2.0" % "test"
 
-libraryDependencies += "org.graalvm.js" % "js" % "20.2.0" % "test"
+  libraryDependencies += "org.graalvm.js" % "js" % "20.2.0" % "test"
 
-libraryDependencies += "org.graalvm.js" % "js-scriptengine" % "20.2.0" % "test"
+  libraryDependencies += "org.graalvm.js" % "js-scriptengine" % "20.2.0" % "test"
+} else {
+  test in assembly := {}
+}
 
 mainClass in Compile := Some("millfork.Main")
 


### PR DESCRIPTION
Furthers the work I started in #36, enabling switching between testing and building without tests with a single flag (no file modifications required).

Standard building:
```
sbt compile
sbt assembly
```

Building with tests:
```
sbt -DincludeTests compile
sbt -DincludeTests assembly
```

@KarolS, make sure to try this out with tests before merging. I still haven't set up a testing environment, so I may have messed something up.