### PR TITLE
Removed optimization hint debug println statements

### DIFF
--- a/src/main/scala/millfork/output/AbstractAssembler.scala
+++ b/src/main/scala/millfork/output/AbstractAssembler.scala
@@ -280,7 +280,6 @@ abstract class AbstractAssembler[T <: AbstractCode](private val program: Program
         gatherFunctionOptimizationHints(options, niceFunctionProperties, function)
       case _ =>
     }
-    println(niceFunctionProperties)
     val aliases = env.getAliases
     recommendedCompilationOrder.foreach { f =>
       if (!env.isAlias(f)) env.maybeGet[NormalFunction](f).foreach { function =>

--- a/src/main/scala/millfork/output/MosAssembler.scala
+++ b/src/main/scala/millfork/output/MosAssembler.scala
@@ -251,8 +251,6 @@ class MosAssembler(program: Program,
     import MosNiceFunctionProperty._
     import NiceFunctionProperty._
     val functionName = function.name
-    println(functionName)
-    println(function.optimizationHints)
     if (function.optimizationHints("even")) niceFunctionProperties += Bit0OfA(false) -> functionName
     if (function.optimizationHints("odd")) niceFunctionProperties += Bit0OfA(true) -> functionName
     if (function.optimizationHints("preserves_a")) niceFunctionProperties += DoesntChangeA -> functionName


### PR DESCRIPTION
After merging master into #81 I noticed a lot of function name and Set()s being logged to stdout. This PR removes those logging statement, keeping the CLI clean.