### PR TITLE
gb library code updates to current syntax

### DIFF
--- a/include/gb_header_small.mfk
+++ b/include/gb_header_small.mfk
@@ -4,7 +4,7 @@
 
 #pragma zilog_syntax
 
-array __header @ $100 = [
+const array __header @ $100 = [
     $00, $C3, $50, $01, $CE, $ED, $66, $66,   $CC, $0D, $00, $0B, $03, $73, $00, $83,
     $00, $0C, $00, $0D, $00, $08, $11, $1F,   $88, $89, $00, $0E, $DC, $CC, $6E, $E6,
     $DD, $DD, $D9, $99, $BB, $BB, $67, $63,   $6E, $0E, $EC, $CC, $DD, $DC, $99, $9F,

--- a/include/gb_joy.mfk
+++ b/include/gb_joy.mfk
@@ -38,9 +38,9 @@ void read_joy() {
         ld a,(reg_joypad)
         ld a,(reg_joypad)
     }
-    byte tmp
+    
     tmp = reg_joypad ^ $ff
-    input_a = (tmp & 1) >> 0
+    input_a = (tmp & 1) // >> 0  
     input_b = (tmp & 2) >> 1
     input_select = (tmp & 4) >> 2
     input_start = (tmp & 8) >> 3


### PR DESCRIPTION
This gets the example code compiling again (and working, I think.)