### PR TITLE
Update x16_experimental.ini

### DIFF
--- a/include/platform/x16_experimental.ini
+++ b/include/platform/x16_experimental.ini
@@ -11,7 +11,8 @@ modules=loader_0801,x16_kernal,x16_hardware,c64_panic,stdlib
 
 [allocation]
 ; Let's not use the BASIC:
-zp_pointers=0-$7F
+; $00-$01 are used for bank switching
+zp_pointers=$02-$7F
 segments=default,himem_00,himem_ff
 default_code_segment=default
 segment_default_start=$80D

--- a/include/platform/x16_experimental.ini
+++ b/include/platform/x16_experimental.ini
@@ -13,12 +13,18 @@ modules=loader_0801,x16_kernal,x16_hardware,c64_panic,stdlib
 ; Let's not use the BASIC:
 ; $00-$01 are used for bank switching
 zp_pointers=$02-$7F
-segments=default,himem_00,himem_ff
+segments=default,user,himem_00,himem_ff
 default_code_segment=default
 segment_default_start=$80D
 segment_default_codeend=$9eff
 segment_default_datastart=after_code
 segment_default_end=$9eff
+
+;1KB user space
+segment_user_start=$0400
+segment_user_codeend=$07ff
+segment_user_datastart=after_code
+segment_user_end=$07ff
 
 segment_himem_00_start=$a000
 segment_himem_00_codeend=$bfff


### PR DESCRIPTION
$00-$01 are used for bank switching.
Unintentional write to those results in a crash.

This could also be solved by adding something like this somewhere in includes:
```
volatile byte RAM_bank @$00
volatile byte ROM_bank @$01
```

(note: in old R38 emulator writing to $00 didn't crash, because bank switching only worked through ports @$9F60-$9F61. In R39 it crashes.)