### PR TITLE
on A8 default use case is BASIC turned on

### DIFF
--- a/include/platform/a8.ini
+++ b/include/platform/a8.ini
@@ -33,7 +33,7 @@ screen_encoding=atasciiscr
 zp_bytes=$80-$FF
 segment_default_start=$2000
 ; BASIC turned off
-segment_default_end=$BFFF
+segment_default_end=$9FFF
 
 [define]
 ATARI_8=1


### PR DESCRIPTION
it was my mistake, sorry